### PR TITLE
impl first_normal_slot and slots_per_epoch

### DIFF
--- a/solana-bankrun/index.ts
+++ b/solana-bankrun/index.ts
@@ -342,6 +342,14 @@ export class ProgramTestContext {
 	get lastBlockhash(): string {
 		return this.inner.lastBlockhash;
 	}
+	/** The first slot after the warmup period. */
+	get firstNormalSlot(): bigint {
+		return this.inner.firstNormalSlot;
+	}
+	/** The number of slots per epoch as set at genesis. */
+	get slotsPerEpoch(): bigint {
+		return this.inner.slotsPerEpoch;
+	}
 	/**
 	 * Create or overwrite an account, subverting normal runtime checks.
 	 *

--- a/solana-bankrun/internal.d.ts
+++ b/solana-bankrun/internal.d.ts
@@ -158,6 +158,8 @@ export class ProgramTestContext {
   get banksClient(): BanksClient
   get payer(): Uint8Array
   get lastBlockhash(): string
+  get firstNormalSlot(): bigint
+  get slotsPerEpoch(): bigint
   setAccount(address: Uint8Array, account: Account): void
   setClock(clock: Clock): void
   setRent(rent: Rent): void

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -715,6 +715,16 @@ impl ProgramTestContext {
         self.0.last_blockhash.to_string()
     }
 
+    #[napi(getter)]
+    pub fn first_normal_slot(&self) -> u64 {
+        self.0.genesis_config().epoch_schedule.first_normal_slot
+    }
+
+    #[napi(getter)]
+    pub fn slots_per_epoch(&self) -> u64 {
+        self.0.genesis_config().epoch_schedule.slots_per_epoch
+    }
+
     #[napi]
     pub fn set_account(&mut self, address: Uint8Array, account: &Account) {
         let acc_original: &AccountOriginal = account.as_ref();

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -96,6 +96,17 @@ test("warp", async () => {
 	expect(slot1).toBe(newSlot);
 });
 
+test("warp epoch", async () => {
+	const context = await start([], []);
+	const client = context.banksClient;
+	context.warpToSlot(context.firstNormalSlot);
+	const slotBefore = await client.getSlot();
+	const epochBefore = (await client.getClock()).epoch;
+	context.warpToSlot(slotBefore + context.slotsPerEpoch);
+	const epochAfter = (await client.getClock()).epoch;
+	expect(epochAfter).toBe(epochBefore + 1n);
+});
+
 test("many instructions", async () => {
 	const [ctx, programId, greetedPubkey] = await helloworldProgram();
 	const ix = new TransactionInstruction({


### PR DESCRIPTION
this makes it easy to advance epoch-by-epoch as shown in the test. note there is a print from tests `ERROR solana_runtime::bank] Burned 21 rent lamports instead of sending to 11111115RidqCHAoz6dzmXxGcfWLNzevYqNpaRAUo` when warping past the warmup (the address is pubkey zero, im not sure what account is paying rent tho?) 