### PR TITLE
Serialize without verification of signatures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ target/
 .temp
 .cache
 dist/
+
+.idea/

--- a/solana-bankrun/index.ts
+++ b/solana-bankrun/index.ts
@@ -36,6 +36,7 @@ import {
 	VersionedTransaction,
 	InflationGovernor,
 	Cluster,
+	SerializeConfig,
 } from "@solana/web3.js";
 import bs58 from "bs58";
 
@@ -220,9 +221,13 @@ export class BanksClient {
 	/**
 	 * Send a transaction and return immediately.
 	 * @param tx - The transaction to send.
+	 * @param serializeConfig - The transaction serialization config.
 	 */
-	async sendTransaction(tx: Transaction | VersionedTransaction) {
-		const serialized = tx.serialize();
+	async sendTransaction(
+		tx: Transaction | VersionedTransaction,
+		serializeConfig?: SerializeConfig,
+	) {
+		const serialized = tx.serialize(serializeConfig);
 		const internal = this.inner;
 		const method =
 			tx instanceof Transaction
@@ -234,12 +239,14 @@ export class BanksClient {
 	/**
 	 * Process a transaction and return the result with metadata.
 	 * @param tx - The transaction to send.
+	 * @param serializeConfig - The transaction serialization config.
 	 * @returns The transaction result and metadata.
 	 */
 	async processTransaction(
 		tx: Transaction | VersionedTransaction,
+		serializeConfig?: SerializeConfig,
 	): Promise<BanksTransactionMeta> {
-		const serialized = tx.serialize();
+		const serialized = tx.serialize(serializeConfig);
 		const internal = this.inner;
 		const inner =
 			tx instanceof Transaction
@@ -258,12 +265,14 @@ export class BanksClient {
 	 * and make assertions about things like log messages.
 	 *
 	 * @param tx - The transaction to send.
+	 * @param serializeConfig - The transaction serialization config.
 	 * @returns The transaction result and metadata.
 	 */
 	async tryProcessTransaction(
 		tx: Transaction | VersionedTransaction,
+		serializeConfig?: SerializeConfig,
 	): Promise<BanksTransactionResultWithMeta> {
-		const serialized = tx.serialize();
+		const serialized = tx.serialize(serializeConfig);
 		const internal = this.inner;
 		const inner =
 			tx instanceof Transaction
@@ -276,14 +285,16 @@ export class BanksClient {
 	 * Simulate a transaction at the given commitment level.
 	 * @param tx - The transaction to simulate.
 	 * @param commitment - The commitment to use.
+	 * @param serializeConfig - The transaction serialization config.
 	 * @returns The transaction simulation result.
 	 */
 	async simulateTransaction(
 		tx: Transaction | VersionedTransaction,
 		commitment?: Commitment,
+		serializeConfig?: SerializeConfig,
 	): Promise<BanksTransactionResultWithMeta> {
 		const internal = this.inner;
-		const serialized = tx.serialize();
+		const serialized = tx.serialize(serializeConfig);
 		const commitmentConverted = convertCommitment(commitment);
 		const inner =
 			tx instanceof Transaction


### PR DESCRIPTION
Hello,

first, thank you for this great tooling for testing of the Solana programs. I started to use it and I really appreciate it.

This PR is more a proposal for discussion (I'm not sure about guidelines for contribution and there could be missing some parts).

For sending transactions I miss a chance to omit verification of signatures at the client side. I would like to pass to the `serialize` call the `SerializeConfig`  (https://github.com/solana-labs/solana-web3.js/blob/v1.87.6/packages/library-legacy/src/transaction/legacy.ts#L795).

To setup like
```
{requireAllSignatures: false, verifySignatures: false}
```

For the client call there could be possible to use the `sendRawTransaction`
https://github.com/solana-labs/solana-web3.js/blob/v1.87.6/packages/library-legacy/src/connection.ts#L5876
which seems to be problematic in case of bankrun.
Passing the parameter to `sendTransaction` calls could be potentially a way.

I'm happy to adjust the code base on the feedback. If this change is not convenient feel free to close the pr. Thanks.