### PR TITLE
Add deactivate feature flag to start of bankrun

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,7 @@
 	"version": "0.3.0",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"files": [
-		"dist/"
-	],
+	"files": ["dist/"],
 	"napi": {
 		"name": "solana-bankrun",
 		"triples": {

--- a/solana-bankrun/index.ts
+++ b/solana-bankrun/index.ts
@@ -500,6 +500,7 @@ export interface AddedAccount {
  * @param accounts - An array of objects indicating what data to write to the given addresses.
  * @param computeMaxUnits - Override the default compute unit limit for a transaction.
  * @param transactionAccountLockLimit - Override the default transaction account lock limit.
+ * @param deactivateFeatures - A list of feature IDs (pubkeys) to deactivate.
  * @returns A container for stuff you'll need to send transactions and interact with the test environment.
  */
 export async function start(
@@ -507,12 +508,14 @@ export async function start(
 	accounts: AddedAccount[],
 	computeMaxUnits?: bigint,
 	transactionAccountLockLimit?: bigint,
+	deactivateFeatures?: PublicKey[],
 ): Promise<ProgramTestContext> {
 	const ctx = await startInner(
 		programs.map((p) => [p.name, p.programId.toBytes()]),
 		accounts.map((a) => [a.address.toBytes(), fromAccountInfo(a.info)]),
 		computeMaxUnits,
 		transactionAccountLockLimit,
+		deactivateFeatures?.map((pk) => pk.toBytes()) ?? [],
 	);
 	return new ProgramTestContext(ctx);
 }
@@ -528,6 +531,7 @@ export async function start(
  * @param accounts - An array of objects indicating what data to write to the given addresses.
  * @param computeMaxUnits - Override the default compute unit limit for a transaction.
  * @param transactionAccountLockLimit - Override the default transaction account lock limit.
+ * @param deactivateFeatures - A list of feature IDs (pubkeys) to deactivate.
  * @returns A container for stuff you'll need to send transactions and interact with the test environment.
  */
 export async function startAnchor(
@@ -536,6 +540,7 @@ export async function startAnchor(
 	accounts: AddedAccount[],
 	computeMaxUnits?: bigint,
 	transactionAccountLockLimit?: bigint,
+	deactivateFeatures?: PublicKey[],
 ): Promise<ProgramTestContext> {
 	const ctx = await startAnchorInner(
 		path,
@@ -543,6 +548,7 @@ export async function startAnchor(
 		accounts.map((a) => [a.address.toBytes(), fromAccountInfo(a.info)]),
 		computeMaxUnits,
 		transactionAccountLockLimit,
+		deactivateFeatures?.map((pk) => pk.toBytes()) ?? [],
 	);
 	return new ProgramTestContext(ctx);
 }

--- a/solana-bankrun/internal.d.ts
+++ b/solana-bankrun/internal.d.ts
@@ -8,8 +8,8 @@ export const enum CommitmentLevel {
   Confirmed = 1,
   Finalized = 2
 }
-export function startAnchor(path: string, extraPrograms: Array<[string, Uint8Array]>, accounts: Array<[Uint8Array, Account]>, computeMaxUnits?: bigint | undefined | null, transactionAccountLockLimit?: bigint | undefined | null): Promise<ProgramTestContext>
-export function start(programs: Array<[string, Uint8Array]>, accounts: Array<[Uint8Array, Account]>, computeMaxUnits?: bigint | undefined | null, transactionAccountLockLimit?: bigint | undefined | null): Promise<ProgramTestContext>
+export function startAnchor(path: string, extraPrograms: Array<[string, Uint8Array]>, accounts: Array<[Uint8Array, Account]>, computeMaxUnits?: bigint | undefined | null, transactionAccountLockLimit?: bigint | undefined | null, deactivateFeatures?: Array<Uint8Array> | undefined | null): Promise<ProgramTestContext>
+export function start(programs: Array<[string, Uint8Array]>, accounts: Array<[Uint8Array, Account]>, computeMaxUnits?: bigint | undefined | null, transactionAccountLockLimit?: bigint | undefined | null, deactivateFeatures?: Array<Uint8Array> | undefined | null): Promise<ProgramTestContext>
 export class Account {
   constructor(lamports: bigint, data: Uint8Array, owner: Uint8Array, executable: boolean, rentEpoch: bigint)
   get lamports(): bigint


### PR DESCRIPTION
I would like to make it possible to configure the deactivated feature on starting the program test from Bankrun.
I have got tests working with stake accounts and I would need to deactivate the `9onWzzvCzNC2jfhxxeqRgs5q7nFAAKpCUvkj6T6GJK9i`/`Raise minimum stake delegation to 1.0 SOL #24357` that is not activated at mainnet and I would like to deactivate it for my testing as well.